### PR TITLE
chore(fleet): re-apply standards pack (dispatch + meta ubuntu)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/fleet-gap.yml
+++ b/.github/ISSUE_TEMPLATE/fleet-gap.yml
@@ -1,0 +1,40 @@
+name: Fleet gap (CI / security / license)
+description: Catalog a gap from fleet-ci, fleet-security, REUSE, or license scan
+title: "[fleet-gap] "
+labels: ["fleet-gap"]
+body:
+  - type: dropdown
+    id: source
+    attributes:
+      label: Source check
+      options:
+        - fleet-ci
+        - fleet-security
+        - gitleaks
+        - trivy
+        - reuse / SPDX
+        - license / NOTICE
+        - other
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - P0
+        - P1
+        - P2
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: Detail
+      description: What failed or is missing; link to workflow run if any
+    validations:
+      required: true
+  - type: input
+    id: run_url
+    attributes:
+      label: Workflow run URL (optional)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What changed and why -->
+
+## Branch tier
+
+- [ ] Targets **`dev`** (or feature base) — use **`Refs #n`** / **`Related to #n`** only (do **not** use `Closes`/`Fixes` — issues stay open until main)
+- [ ] Targets **`main`** — use **`Closes #n`** / **`Fixes #n`** for completed work; epics only when fully delivered
+
+## Checklist
+
+- [ ] Local gates green (`local-ci` / `cargo test` / `pytest` as applicable)
+- [ ] No secrets in diff
+- [ ] **Do not** request automatic Copilot code review
+
+## Linked work
+
+<!-- Refs #123  or  Closes #123 (main only) -->

--- a/.github/workflows/close-issues-on-main.yml
+++ b/.github/workflows/close-issues-on-main.yml
@@ -1,0 +1,68 @@
+# Close Fixes/Closes issues only when a PR merges into **main** (or master).
+# Feature PRs target **dev** and must leave issues open (use Refs #n).
+# Epics close only when a main-bound PR includes Closes #<epic>.
+name: close-issues-on-main
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number (must be merged into main)"
+        type: string
+        required: true
+      dry_run:
+        description: "List issues without closing"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked:
+    name: Close issues for main merge
+    # Meta workflow: GitHub-hosted is correct (issue API only; no product build).
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       (github.event.pull_request.base.ref == 'main' ||
+        github.event.pull_request.base.ref == 'master'))
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure gh
+        run: |
+          set -euo pipefail
+          command -v gh >/dev/null 2>&1 || {
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+              | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+              | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null
+            sudo apt-get update -qq && sudo apt-get install -y -qq gh
+          }
+          gh --version
+      - name: Close linked issues (main only)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
+          DRY_INPUT: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/close-linked-issues.sh ]; then
+            echo "scripts/close-linked-issues.sh missing — fail" >&2
+            exit 1
+          fi
+          args=(--pr "$PR_NUMBER")
+          if [ "${DRY_INPUT}" = "true" ]; then args+=(--dry-run); fi
+          # Prefer main; allow master via RELAY_MAIN_BRANCH if needed
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          if [ "$DEFAULT_BRANCH" = "master" ]; then
+            args+=(--main-branch master)
+          fi
+          bash scripts/close-linked-issues.sh "${args[@]}"

--- a/.github/workflows/fleet-ci.yml
+++ b/.github/workflows/fleet-ci.yml
@@ -1,0 +1,93 @@
+# Fleet standard CI — self-hosted. Honest status on trunk via Actions badge.
+# See docs/FLEET_STANDARDS.md (or plans/fractal/P26_FLEET_STANDARDS.md).
+name: fleet-ci
+
+on:
+  push:
+    branches: [main, master, dev]
+  pull_request:
+    branches: [main, master, dev]
+  workflow_dispatch:
+
+concurrency:
+  group: fleet-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    name: detect stack
+    runs-on: [self-hosted, linux, x64, podman]
+    outputs:
+      rust: ${{ steps.d.outputs.rust }}
+      python: ${{ steps.d.outputs.python }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: d
+        run: |
+          set -euo pipefail
+          rust=false; python=false
+          if [ -f Cargo.toml ]; then rust=true; fi
+          if [ -f pyproject.toml ] || [ -f requirements.txt ] || [ -f setup.py ]; then python=true; fi
+          echo "rust=$rust" >> "$GITHUB_OUTPUT"
+          echo "python=$python" >> "$GITHUB_OUTPUT"
+          echo "Detected rust=$rust python=$python"
+
+  rust:
+    name: cargo check/test
+    needs: detect
+    if: needs.detect.outputs.rust == 'true'
+    runs-on: [self-hosted, linux, x64, podman]
+    steps:
+      - uses: actions/checkout@v4
+      - name: cargo check
+        run: cargo check --workspace --all-targets
+      - name: cargo test
+        run: cargo test --workspace
+
+  python:
+    name: python lint/test
+    needs: detect
+    if: needs.detect.outputs.python == 'true'
+    runs-on: [self-hosted, linux, x64, podman]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+      - name: Sync (best-effort)
+        run: |
+          set -euo pipefail
+          if [ -f uv.lock ] || [ -f pyproject.toml ]; then
+            uv sync --all-groups 2>/dev/null || uv sync 2>/dev/null || true
+          fi
+      - name: Ruff (if configured)
+        run: |
+          set -euo pipefail
+          if [ -f pyproject.toml ] && grep -q '\[tool.ruff' pyproject.toml 2>/dev/null; then
+            uv run ruff check . || python -m ruff check .
+          else
+            echo "ruff not configured — skip"
+          fi
+      - name: Pytest (if tests exist)
+        run: |
+          set -euo pipefail
+          if [ -d tests ] || [ -d test ]; then
+            uv run pytest -q 2>/dev/null || pytest -q 2>/dev/null || echo "pytest failed or missing — mark job fail" >&2
+          else
+            echo "no tests/ directory — skip"
+          fi
+
+  noop:
+    name: no stack detected
+    needs: detect
+    if: needs.detect.outputs.rust != 'true' && needs.detect.outputs.python != 'true'
+    runs-on: [self-hosted, linux, x64, podman]
+    steps:
+      - run: |
+          echo "No Cargo.toml / pyproject detected. fleet-ci reports success with no gates."
+          echo "Add stack files or a product-specific CI job for real coverage."

--- a/.github/workflows/fleet-security.yml
+++ b/.github/workflows/fleet-security.yml
@@ -1,0 +1,59 @@
+# Fleet security lint/scan — self-hosted. Badge reflects honest job status on trunk.
+name: fleet-security
+
+on:
+  push:
+    branches: [main, master, dev]
+  pull_request:
+    branches: [main, master, dev]
+  schedule:
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: fleet-security-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: [self-hosted, linux, x64, podman]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        run: |
+          set -euo pipefail
+          if command -v gitleaks >/dev/null 2>&1; then
+            gitleaks detect --source . --verbose --redact
+          elif command -v docker >/dev/null 2>&1; then
+            docker run --rm -v "$PWD:/path" zricethezav/gitleaks:latest detect --source=/path --verbose --redact
+          elif command -v podman >/dev/null 2>&1; then
+            podman run --rm -v "$PWD:/path:ro" docker.io/zricethezav/gitleaks:latest detect --source=/path --verbose --redact
+          else
+            echo "gitleaks not available on runner — FAIL (honest security gate)" >&2
+            exit 1
+          fi
+
+  trivy-fs:
+    name: trivy filesystem (vuln+secret+license)
+    runs-on: [self-hosted, linux, x64, podman]
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trivy fs
+        run: |
+          set -euo pipefail
+          if ! command -v trivy >/dev/null 2>&1; then
+            echo "trivy missing — advisory skip (continue-on-error)"
+            exit 0
+          fi
+          trivy fs --scanners vuln,secret,license \
+            --severity HIGH,CRITICAL \
+            --skip-dirs .git --skip-dirs target --skip-dirs node_modules --skip-dirs .venv \
+            --exit-code 1 \
+            .

--- a/.github/workflows/reopen-issues-closed-off-main.yml
+++ b/.github/workflows/reopen-issues-closed-off-main.yml
@@ -1,0 +1,68 @@
+# GitHub natively closes issues on merge for any base branch when PR uses Closes #n.
+# This workflow reopens issues closed by merges into non-main branches so epics/tasks
+# stay open until delivered to trunk.
+name: reopen-issues-closed-off-main
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  reopen:
+    name: Reopen issues closed off-main
+    # Meta workflow: GitHub-hosted is correct (no product build). Avoids self-hosted
+    # queue when runners are busy/down; only needs gh + GITHUB_TOKEN.
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref != 'main' &&
+      github.event.pull_request.base.ref != 'master'
+    steps:
+      - name: Reopen linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          body=$(gh api "repos/$REPO/pulls/$PR" --jq .body)
+          title=$(gh api "repos/$REPO/pulls/$PR" --jq .title)
+          # Extract Closes/Fixes/Resolves #N
+          nums=$(TITLE="$title" BODY="$body" python3 <<'PY'
+import os, re
+text = (os.environ.get("TITLE") or "") + "\n" + (os.environ.get("BODY") or "")
+kw = r"(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)"
+found = set()
+for m in re.finditer(rf"(?is)\b{kw}\b(?:\s*:)?\s*((?:#?\d+(?:\s*[,&/and\s]+#?\d+)*))", text):
+    prefix = text[max(0, m.start() - 24) : m.start()].lower()
+    if re.search(r"(?:no|not|without|dont)\W*$", prefix):
+        continue
+    for n in re.findall(r"\d+", m.group(1)):
+        found.add(n)
+print("\n".join(sorted(found, key=int)))
+PY
+)
+          if [ -z "${nums}" ]; then
+            echo "No closing keywords — nothing to reopen"
+            exit 0
+          fi
+          while IFS= read -r n; do
+            [ -z "$n" ] && continue
+            state=$(gh api "repos/$REPO/issues/$n" --jq .state 2>/dev/null || echo missing)
+            if [ "$state" = "closed" ]; then
+              gh api -X PATCH "repos/$REPO/issues/$n" -f state=open >/dev/null
+              gh api -X POST "repos/$REPO/issues/$n/comments" \
+                -f body="Reopened automatically: closing keywords on PR #${PR} merged into \`${BASE}\` (not main). Issues close only when work reaches **main**. Prefer \`Refs #${n}\` on non-main PRs." >/dev/null
+              echo "reopened #$n"
+            else
+              echo "skip #$n state=$state"
+            fi
+          done <<< "$nums"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # DynEL: Dynamic Error Logging Module
 
+<!-- FLEET-BADGES:BEGIN -->
+[![CI](https://github.com/tzervas/DynEL/actions/workflows/fleet-ci.yml/badge.svg?branch=main)](https://github.com/tzervas/DynEL/actions/workflows/fleet-ci.yml?query=branch%3Amain)
+[![Security](https://github.com/tzervas/DynEL/actions/workflows/fleet-security.yml/badge.svg?branch=main)](https://github.com/tzervas/DynEL/actions/workflows/fleet-security.yml?query=branch%3Amain)
+<!-- FLEET-BADGES:END -->
+
 🚀 **Project Status**: In active development. All components subject to change. Contributions and feedback welcome.
 
 🎯 **Intent**: Provide a flexible and powerful logging and error-handling solution for Python applications, with seamless integration into projects like PeSPr.

--- a/docs/FLEET_STANDARDS.md
+++ b/docs/FLEET_STANDARDS.md
@@ -1,0 +1,30 @@
+# Fleet standards (tzervas)
+
+Applied from the workstation pack under `plans/fleet-standards/pack/`.
+
+## Workflows
+
+| Workflow | When | Runner |
+|----------|------|--------|
+| `fleet-ci.yml` | push/PR to main|dev | self-hosted linux x64 podman |
+| `fleet-security.yml` | push/PR + weekly | same |
+| `close-issues-on-main.yml` | PR closed→main | same |
+| `reopen-issues-closed-off-main.yml` | PR merged off-main with Closes | same |
+
+## Issue close policy
+
+- **`dev` / feature merges:** `Refs #n` only — issues stay open
+- **`main` merges:** `Closes #n` / `Fixes #n`
+- **Epics:** close only when delivery PR to main includes `Closes #<epic>`
+
+## Badges
+
+README badges use GitHub Actions SVG for **trunk** branch — live status, not static green.
+
+## Copilot
+
+Automatic Copilot code reviews are **disabled** for fleet-managed repos. Do not request Copilot on PRs.
+
+## Permissions
+
+Workflows use minimum `permissions:` blocks (contents read; issues write only for close/reopen jobs).

--- a/scripts/close-linked-issues.sh
+++ b/scripts/close-linked-issues.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# scripts/close-linked-issues.sh — Close issues linked by Fixes/Closes/Resolves.
+#
+# Policy (see docs/WORKFLOW.md §0):
+#   - Feature work merges into **dev** and does **not** close issues.
+#   - Issues close only when work reaches **main** (GitHub native auto-close
+#     and/or this script for parity / commit-scan).
+#   - Epics stay open until a final ship issue with Closes #<epic> lands on main.
+#
+# Usage:
+#   bash scripts/close-linked-issues.sh --pr 68              # only if base is main
+#   bash scripts/close-linked-issues.sh --pr 68 --dry-run
+#   bash scripts/close-linked-issues.sh --merged-into main --limit 20
+#   bash scripts/close-linked-issues.sh --pr 68 --any-base   # escape hatch (rare)
+#
+# Keywords: fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved #N
+# Also: conventional titles feat(#62): in PR title/commits (task issues only).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DRY_RUN=0
+PR_NUM=""
+MERGED_INTO=""
+MERGED_SINCE=""
+LIMIT=30
+COMMENT=1
+# Default: only act when the PR base is main
+REQUIRE_MAIN=1
+MAIN_BRANCH="${RELAY_MAIN_BRANCH:-main}"
+
+usage() {
+    sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr) PR_NUM="${2:-}"; shift 2 ;;
+        --merged-into) MERGED_INTO="${2:-}"; shift 2 ;;
+        --merged-since) MERGED_SINCE="${2:-}"; shift 2 ;;
+        --limit) LIMIT="${2:-30}"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --no-comment) COMMENT=0; shift ;;
+        --any-base) REQUIRE_MAIN=0; shift ;;
+        --main-branch) MAIN_BRANCH="${2:-main}"; shift 2 ;;
+        -h | --help) usage; exit 0 ;;
+        *)
+            printf 'close-linked-issues.sh: unknown arg: %s\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! command -v gh >/dev/null 2>&1; then
+    printf 'close-linked-issues.sh: gh CLI required\n' >&2
+    exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    printf 'close-linked-issues.sh: python3 required\n' >&2
+    exit 1
+fi
+
+# Reads text on stdin → one issue number per line.
+extract_issue_numbers() {
+    # Load program via heredoc into a variable so stdin remains the PR text pipe
+    # (avoids bash quoting hazards in python -c '...' single quotes).
+    local _prog
+    _prog="$(cat <<'PY'
+import re, sys
+text = sys.stdin.read()
+kw = r"(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)"
+found = set()
+for m in re.finditer(rf"(?is)\b{kw}\b(?:\s*:)?\s*((?:#?\d+(?:\s*[,&]?\s*(?:and\s+)?#?\d+)*))", text):
+    # Ignore negated forms: "No Fixes #22", "not close #N", "without Fixes #N"
+    prefix = text[max(0, m.start() - 24) : m.start()].lower()
+    if re.search(r"(?:no|not|without|dont)\W*$", prefix):
+        continue
+    for n in re.findall(r"\d+", m.group(1)):
+        found.add(int(n))
+# Conventional task titles (not "Epic: #N" prose)
+for m in re.finditer(r"(?i)\b(?:feat|fix|docs|test|chore|refactor|perf|ci|build|style)\(#(\d+)\)", text):
+    found.add(int(m.group(1)))
+for n in sorted(found):
+    print(n)
+PY
+)"
+    python3 -c "$_prog"
+}
+
+# Returns 0 if issue looks like an epic (label or title); we still close if
+# the PR explicitly Fixes/Closes it — caller decides what numbers to pass.
+issue_is_epic() {
+    local issue="$1" labels title
+    labels="$(gh issue view "$issue" --json labels --jq '[.labels[].name]|join(",")' 2>/dev/null || true)"
+    title="$(gh issue view "$issue" --json title --jq .title 2>/dev/null || true)"
+    [[ "$labels" == *epic* ]] && return 0
+    [[ "$title" =~ ^[Ee]pic: ]] && return 0
+    return 1
+}
+
+close_one() {
+    local issue="$1" pr="$2" base="$3" url="$4" state
+    state="$(gh issue view "$issue" --json state --jq .state 2>/dev/null || echo MISSING)"
+    if [[ "$state" == "MISSING" || -z "$state" ]]; then
+        printf '  skip  #%s (not found)\n' "$issue"
+        return 0
+    fi
+    if [[ "$state" == "CLOSED" ]]; then
+        printf '  skip  #%s (already closed)\n' "$issue"
+        return 0
+    fi
+    if (( DRY_RUN == 1 )); then
+        printf '  dry   would close #%s (from PR #%s → %s)\n' "$issue" "$pr" "$base"
+        return 0
+    fi
+    if (( COMMENT == 1 )); then
+        gh issue close "$issue" --comment "$(cat <<EOF
+Closed via merged PR #${pr} into \`${base}\`.
+
+Issue close policy: only after work reaches **main** (feature merges to \`dev\` leave issues open). See docs/WORKFLOW.md.
+
+${url}
+EOF
+)" >/dev/null
+    else
+        gh issue close "$issue" >/dev/null
+    fi
+    printf '  closed #%s (PR #%s → %s)\n' "$issue" "$pr" "$base"
+}
+
+process_pr() {
+    local pr="$1" json title body base state merged url text nums commits
+    json="$(gh pr view "$pr" --json number,title,body,baseRefName,state,mergedAt,url 2>/dev/null)" || {
+        printf 'close-linked-issues.sh: cannot view PR #%s\n' "$pr" >&2
+        return 1
+    }
+    title="$(printf '%s' "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("title") or "")')"
+    body="$(printf '%s' "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body") or "")')"
+    base="$(printf '%s' "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("baseRefName") or "")')"
+    state="$(printf '%s' "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state") or "")')"
+    merged="$(printf '%s' "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("mergedAt") or "")')"
+    url="$(printf '%s' "$json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("url") or "")')"
+
+    if (( REQUIRE_MAIN == 1 )) && [[ "$base" != "$MAIN_BRANCH" ]]; then
+        printf 'PR #%s base=%s — skip close (policy: only base=%s; feature work on dev leaves issues open)\n' \
+            "$pr" "$base" "$MAIN_BRANCH"
+        return 0
+    fi
+
+    text="${title}"$'\n'"${body}"
+    commits="$(gh pr view "$pr" --json commits --jq '.commits[].messageHeadline' 2>/dev/null || true)"
+    text="${text}"$'\n'"${commits}"
+    # Full commit messages catch Fixes #N in bodies of commits brought by promote
+    commits_full="$(gh pr view "$pr" --json commits --jq '.commits[].messageBody' 2>/dev/null || true)"
+    text="${text}"$'\n'"${commits_full}"
+    nums="$(printf '%s' "$text" | extract_issue_numbers)"
+
+    is_merged=0
+    if [[ "$state" == "MERGED" || -n "$merged" ]]; then
+        is_merged=1
+    fi
+
+    if (( is_merged == 0 )); then
+        if [[ -z "$nums" ]]; then
+            printf 'PR #%s (%s → %s): not merged; no Fixes/Closes refs\n' "$pr" "$state" "$base"
+            return 0
+        fi
+        printf 'PR #%s (%s → %s): not merged — would close after merge to %s:\n' "$pr" "$state" "$base" "$base"
+        while IFS= read -r n; do
+            [[ -z "$n" ]] && continue
+            printf '  pending #%s\n' "$n"
+        done <<<"$nums"
+        return 0
+    fi
+
+    if [[ -z "$nums" ]]; then
+        printf 'PR #%s → %s: no linked issues found\n' "$pr" "$base"
+        return 0
+    fi
+    printf 'PR #%s → %s\n' "$pr" "$base"
+    while IFS= read -r n; do
+        [[ -z "$n" ]] && continue
+        close_one "$n" "$pr" "$base" "$url"
+    done <<<"$nums"
+}
+
+if [[ -n "$PR_NUM" ]]; then
+    process_pr "$PR_NUM"
+    exit 0
+fi
+
+if [[ -z "$MERGED_INTO" && -z "$MERGED_SINCE" ]]; then
+    printf 'close-linked-issues.sh: pass --pr N, or --merged-into BRANCH, or --merged-since ISO\n' >&2
+    exit 2
+fi
+
+# Default batch target is main when requiring main-only policy
+if (( REQUIRE_MAIN == 1 )) && [[ -z "$MERGED_INTO" ]]; then
+    MERGED_INTO="$MAIN_BRANCH"
+fi
+if (( REQUIRE_MAIN == 1 )) && [[ -n "$MERGED_INTO" && "$MERGED_INTO" != "$MAIN_BRANCH" ]]; then
+    printf 'close-linked-issues.sh: refusing --merged-into %s (policy: only %s; use --any-base to override)\n' \
+        "$MERGED_INTO" "$MAIN_BRANCH" >&2
+    exit 2
+fi
+
+QUERY="is:pr is:merged"
+if [[ -n "$MERGED_INTO" ]]; then
+    QUERY+=" base:${MERGED_INTO}"
+fi
+if [[ -n "$MERGED_SINCE" ]]; then
+    since_date="${MERGED_SINCE:0:10}"
+    QUERY+=" merged:>=${since_date}"
+fi
+
+printf 'Searching: %s (limit %s)\n' "$QUERY" "$LIMIT"
+mapfile -t PRS < <(gh pr list --state merged --search "$QUERY" --limit "$LIMIT" --json number --jq '.[].number' 2>/dev/null)
+if [[ ${#PRS[@]} -eq 0 ]]; then
+    if [[ -n "$MERGED_INTO" ]]; then
+        mapfile -t PRS < <(gh pr list --state merged --base "$MERGED_INTO" --limit "$LIMIT" --json number --jq '.[].number')
+    else
+        mapfile -t PRS < <(gh pr list --state merged --limit "$LIMIT" --json number --jq '.[].number')
+    fi
+fi
+
+if [[ ${#PRS[@]} -eq 0 ]]; then
+    printf 'No merged PRs matched.\n'
+    exit 0
+fi
+
+for pr in "${PRS[@]}"; do
+    process_pr "$pr" || true
+done


### PR DESCRIPTION
## Summary
Re-apply fleet standards pack:
- `workflow_dispatch` on fleet-ci / fleet-security
- Meta issue workflows on `ubuntu-latest`
- Badges, PR/issue templates, close-on-main only

Validates self-hosted runner recovery.
