### PR TITLE
ci: run all GitHub Actions on self-hosted runners only

### DIFF
--- a/.github/workflows/close-issues-on-main.yml
+++ b/.github/workflows/close-issues-on-main.yml
@@ -27,7 +27,7 @@ jobs:
   close-linked:
     name: Close issues for main merge
     # Meta workflow: GitHub-hosted is correct (issue API only; no product build).
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&

--- a/.github/workflows/reopen-issues-closed-off-main.yml
+++ b/.github/workflows/reopen-issues-closed-off-main.yml
@@ -18,7 +18,7 @@ jobs:
     name: Reopen issues closed off-main
     # Meta workflow: GitHub-hosted is correct (no product build). Avoids self-hosted
     # queue when runners are busy/down; only needs gh + GITHUB_TOKEN.
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, podman]
     if: >
       github.event_name == 'pull_request' &&
       github.event.pull_request.merged == true &&


### PR DESCRIPTION
Pins every plain GitHub-hosted `runs-on` in this repo to the fleet's self-hosted label set.

```diff
- runs-on: ubuntu-latest
+ runs-on: [self-hosted, linux, x64, podman]
```

Files changed: **2**

Deliberately untouched: **0** expression-valued `runs-on` and **0** `windows-*`/`macos-*` jobs. A Linux-only fleet cannot run the latter, and the former need a judgement call rather than a substitution — reported rather than silently broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)